### PR TITLE
Update jira_features.py: Remove Super/Max - Purchasing and rename Super/Max - Upsell Tab to Subscription Upsell Tab

### DIFF
--- a/jeeves/config/jira_features.py
+++ b/jeeves/config/jira_features.py
@@ -43,7 +43,7 @@ JIRA_FEATURES = {
                 "Hearts / Unlimited Hearts": ["heart"],
                 "Super Hooks": [],
                 "Legendary": ["Legendarize"],
-                "Super/Max - Upsell Tab": [],
+                "Subscription Upsell Tab": [],
                 "Mistakes Inbox": [],
                 "Practice Hub": [],
                 "Words List": ["word list"],
@@ -87,7 +87,6 @@ JIRA_FEATURES = {
             },
             "Monetization Engine": {
                 "Max Backend": [],
-                "Super/Max - Purchasing": ["can't purchase"],
             },
             "Subscription Upsell Tab": {
                 "Subscription Upsell Tab": ["subscription tab", "upsell tab"]
@@ -518,7 +517,7 @@ JIRA_FEATURES_DESCRIPTIONS = {
     "Student Plan": "Anything related to the Get Student Plan, Student Plan verification, or Student Plan Prices",
     "Subscription Gifting": "Anything related to subscription gifting",
     "Super Hooks": "Includes Super hooks and session end cards, but excludes Super ads, the purchase flow after entering the Super hook, and the Super/Max upsell tab",
-    "Super/Max - Upsell Tab": "Anything related to the Super/Max upsell tab. Excludes other Super/Max hooks and session end cards",
+    "Subscription Upsell Tab": "Anything related to the Subscription Upsell tab",
     "Tab Redesign": "Redesigning the Profile, Feed, Leaderboard, and Quest tab for visual consistency.",
     "Super/Max - Purchase Flow": "Anything that happens after you enter the subscription purchase flow",
     "Widget": "Problems with widget on home screen or widget reward",


### PR DESCRIPTION
## Summary

This PR updates the `jeeves/config/jira_features.py` file to:

1. **Remove lines 92-94**: Removes the `"Super/Max - Purchasing": ["can't purchase"]` entry from the Monetization Engine section
2. **Update naming**: Changes `"Super/Max - Upsell Tab"` to `"Subscription Upsell Tab"` in two locations:
   - Line 45: In the feature configuration
   - Line 520: In the feature descriptions

## Changes Made

- **Removed**: `"Super/Max - Purchasing": ["can't purchase"]` from the Monetization Engine section
- **Updated**: `"Super/Max - Upsell Tab": []` → `"Subscription Upsell Tab": []`
- **Updated**: `"Super/Max - Upsell Tab": "Anything related to the Super/Max upsell tab..."` → `"Subscription Upsell Tab": "Anything related to the Subscription Upsell tab"`

## Files Changed

- `jeeves/config/jira_features.py`

## Testing

The changes maintain the existing structure and only update the specific text references as requested.